### PR TITLE
对此github储存库的大多数文件加了jsdelivr cdn

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
         <p><b>Softwares:</b></p>
         <a href="https://www.r-project.org/" class="mycol" target='_BLANK'>Download R</a><br>
         <a href="https://rstudio.com/products/rstudio/download/#download" class="mycol" target='_BLANK'>Download R-studio</a><br>
-        <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/r-package-win" class="mycol" target='_BLANK'>Packages for R in Windows</a><br>
+        <a href="https://github.com/wangshan731/DM-ML/raw/master/r-package-win"" class="mycol" target='_BLANK'>Packages for R in Windows</a><br>
         
         <div class="mycol"> <h3>Schedule</h3></div>
         Lecture 1&2: introduction to ML<br>
@@ -117,7 +117,7 @@
                         <td>Apr. 20</td>
                         <td>Lecture 1: Introduction to Machine Learning</td>
                         <td><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-1/l1.pdf" class="mycol" target='_BLANK'>Lecture 1</a><br>
-                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-1/video.rar" class="mycol" target='_BLANK'>Video L1</a><br>
+                                <a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-1/video.rar" class="mycol" target='_BLANK'>Video L1</a><br>
                                 <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/home-reading/home-reading-1a.pdf" class="mycol" target='_BLANK'>Home Reading 1a: Mathematics for ML</a><br>
                                 <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-1/supplementary-reading/rue-lala.pdf" class="mycol" target='_BLANK'>Supplementary reading 1a: Analytics for Rue Lala</a><br>
                                 <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-1/supplementary-reading/introduction-analytics.rar" class="mycol" target='_BLANK'>Supplementary reading 1b: Introduction to Analytics</a>
@@ -135,7 +135,7 @@
                         <td>Apr. 27</td>
                         <td>Lecture 3: Linear Regression and R</td>
                         <td><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-3/l3.pdf" class="mycol" target='_BLANK'>Lecture 3</a><br>
-                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-3/video-lr.rar" class="mycol" target='_BLANK'>Video L3</a><br>
+                                <a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-3/video-lr.rar" class="mycol" target='_BLANK'>Video L3</a><br>
                                 <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-3/r-l3.rar" class="mycol" target='_BLANK'>Lab 3</a><br>
                                 <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-3/references-wine.rar" class="mycol" target='_BLANK'>Supplementary reading 3a: Quality of Wine</a>
                                 </td>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
                 .mycol {color:brown}
         </style>
         
-        
+​        
         <title>LN3119: Data Mining & Machine Learning</title> 
 </head>
 
@@ -24,7 +24,7 @@
         Apr. 27: Class<br>
         May 4: Break
         
-        
+​        
         <div class="mycol"> <h3>News</h3></div>
         Apr. 17: The online class is open at Zoom (conference ID: 688-9275-3034) since Apr. 20.<br>
         <br>
@@ -68,8 +68,9 @@
         <p><b>Acknowledgement:</b></p>
         Haipeng Shen (HKU), Daniel Zheng (SMU), Lai Wei (SJTU), Shuai Li (SJTU), Weinan Zhang (SJTU), Chengzhang Li (SJTU)
 
-        
-               
+
+​        
+​               
         <p><b>References:</b></p>
         <a href="http://faculty.marshall.usc.edu/gareth-james/ISL/" class="mycol" target='_BLANK'>An introduction to statistical learning: R</a> by G. James, D. Witten, T. Hastie, R. Tibshirani<br>
         <a href="http://www.deeplearningbook.org/" class="mycol" target='_BLANK'>Deep Learning</a> by I. Goodfellow, Y. Bengio, A. Courville<br>
@@ -82,21 +83,21 @@
         <a href="https://www.holehouse.org/mlclass/" class="mycol" target='_BLANK'>Stanford Machine Learning</a> by A. Ng
         
         <!--<p><b>References:</b></p>
-        <a href="https://github.com/wangshan731/DM-ML/raw/master/references/ISLR.pdf" class="mycol" target='_BLANK'>An introduction to statistical learning: R</a> by G. James, D. Witten, T. Hastie, R. Tibshirani<br>
+        <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/references/ISLR.pdf" class="mycol" target='_BLANK'>An introduction to statistical learning: R</a> by G. James, D. Witten, T. Hastie, R. Tibshirani<br>
         <a href="http://www.deeplearningbook.org/" class="mycol" target='_BLANK'>Deep Learning</a> by I. Goodfellow, Y. Bengio, A. Courville<br>
-        <a href="https://github.com/wangshan731/DM-ML/raw/master/references/RL.pdf" class="mycol" target='_BLANK'>Reinforcement learning: an introduction</a> by R. S. Sutton and A. G. Barto<br>
-        <a href="https://github.com/wangshan731/DM-ML/raw/master/references/ESL.pdf" class="mycol" target='_BLANK'>The elements of statistical learning</a> by T. Hastie, R. Tibshirani, J. Friedman<br>
-        <a href="https://github.com/wangshan731/DM-ML/raw/master/references/SLM-Li.pdf" class="mycol" target='_BLANK'>统计学习方法</a> by 李航<br>
-        <a href="https://github.com/wangshan731/DM-ML/raw/master/references/ML-Zhou.pdf" class="mycol" target='_BLANK'>机器学习</a> by 周志华<br>
-        <a href="https://github.com/wangshan731/DM-ML/raw/master/references/ML-APP.pdf" class="mycol" target='_BLANK'>Machine learning: a probabilistic perspective</a> by K. P. Murphy<br>
-        <a href="https://github.com/wangshan731/DM-ML/raw/master/references/PR-ML.pdf" class="mycol" target='_BLANK'>Pattern recognition and machine learning</a> by C. M. Bishop<br>
+        <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/references/RL.pdf" class="mycol" target='_BLANK'>Reinforcement learning: an introduction</a> by R. S. Sutton and A. G. Barto<br>
+        <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/references/ESL.pdf" class="mycol" target='_BLANK'>The elements of statistical learning</a> by T. Hastie, R. Tibshirani, J. Friedman<br>
+        <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/references/SLM-Li.pdf" class="mycol" target='_BLANK'>统计学习方法</a> by 李航<br>
+        <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/references/ML-Zhou.pdf" class="mycol" target='_BLANK'>机器学习</a> by 周志华<br>
+        <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/references/ML-APP.pdf" class="mycol" target='_BLANK'>Machine learning: a probabilistic perspective</a> by K. P. Murphy<br>
+        <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/references/PR-ML.pdf" class="mycol" target='_BLANK'>Pattern recognition and machine learning</a> by C. M. Bishop<br>
         <a href="https://www.holehouse.org/mlclass/" class="mycol" target='_BLANK'>Stanford Machine Learning</a> by A. Ng
         -->
         
         <p><b>Softwares:</b></p>
         <a href="https://www.r-project.org/" class="mycol" target='_BLANK'>Download R</a><br>
         <a href="https://rstudio.com/products/rstudio/download/#download" class="mycol" target='_BLANK'>Download R-studio</a><br>
-        <a href="https://github.com/wangshan731/DM-ML/raw/master/r-package-win" class="mycol" target='_BLANK'>Packages for R in Windows</a><br>
+        <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/r-package-win" class="mycol" target='_BLANK'>Packages for R in Windows</a><br>
         
         <div class="mycol"> <h3>Schedule</h3></div>
         Lecture 1&2: introduction to ML<br>
@@ -115,49 +116,49 @@
                 <tr class="row1">
                         <td>Apr. 20</td>
                         <td>Lecture 1: Introduction to Machine Learning</td>
-                        <td><a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-1/l1.pdf" class="mycol" target='_BLANK'>Lecture 1</a><br>
-                                <a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-1/video.rar" class="mycol" target='_BLANK'>Video L1</a><br>
-                                <a href="https://github.com/wangshan731/DM-ML/raw/master/home-reading/home-reading-1a.pdf" class="mycol" target='_BLANK'>Home Reading 1a: Mathematics for ML</a><br>
-                                <a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-1/supplementary-reading/rue-lala.pdf" class="mycol" target='_BLANK'>Supplementary reading 1a: Analytics for Rue Lala</a><br>
-                                <a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-1/supplementary-reading/introduction-analytics.rar" class="mycol" target='_BLANK'>Supplementary reading 1b: Introduction to Analytics</a>
+                        <td><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-1/l1.pdf" class="mycol" target='_BLANK'>Lecture 1</a><br>
+                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-1/video.rar" class="mycol" target='_BLANK'>Video L1</a><br>
+                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/home-reading/home-reading-1a.pdf" class="mycol" target='_BLANK'>Home Reading 1a: Mathematics for ML</a><br>
+                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-1/supplementary-reading/rue-lala.pdf" class="mycol" target='_BLANK'>Supplementary reading 1a: Analytics for Rue Lala</a><br>
+                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-1/supplementary-reading/introduction-analytics.rar" class="mycol" target='_BLANK'>Supplementary reading 1b: Introduction to Analytics</a>
                                 </td>
                 </tr>
                 <tr class="row2">
                         <td>Apr. 26</td>
                         <td>Lecture 2: Basics in Machine Learning</td>
-                        <td><a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-2/l2.pdf" class="mycol" target='_BLANK'>Lecture 2</a><br>
-                                <a href="https://github.com/wangshan731/DM-ML/raw/master/home-reading/home-reading-2a.rar" class="mycol" target='_BLANK'>Home reading 2a: Introduction to R</a><br>
-                                <a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-2/overview-sl.pdf" class="mycol" target='_BLANK'>Supplementary reading 2a: Overview of Supervised Learning</a>
+                        <td><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-2/l2.pdf" class="mycol" target='_BLANK'>Lecture 2</a><br>
+                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/home-reading/home-reading-2a.rar" class="mycol" target='_BLANK'>Home reading 2a: Introduction to R</a><br>
+                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-2/overview-sl.pdf" class="mycol" target='_BLANK'>Supplementary reading 2a: Overview of Supervised Learning</a>
                                 </td>
                 </tr>
                 <tr class="row1">
                         <td>Apr. 27</td>
                         <td>Lecture 3: Linear Regression and R</td>
-                        <td><a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-3/l3.pdf" class="mycol" target='_BLANK'>Lecture 3</a><br>
-                                <a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-3/video-lr.rar" class="mycol" target='_BLANK'>Video L3</a><br>
-                                <a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-3/r-l3.rar" class="mycol" target='_BLANK'>Lab 3</a><br>
-                                <a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-3/references-wine.rar" class="mycol" target='_BLANK'>Supplementary reading 3a: Quality of Wine</a>
+                        <td><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-3/l3.pdf" class="mycol" target='_BLANK'>Lecture 3</a><br>
+                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-3/video-lr.rar" class="mycol" target='_BLANK'>Video L3</a><br>
+                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-3/r-l3.rar" class="mycol" target='_BLANK'>Lab 3</a><br>
+                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-3/references-wine.rar" class="mycol" target='_BLANK'>Supplementary reading 3a: Quality of Wine</a>
                                 </td>
                 </tr>
                 <tr class="row2">
                         <td>May 11</td>
                         <td>Lecture 4: Logistic Regression</td>
-                        <td><a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-4/l4.pdf" class="mycol" target='_BLANK'>Lecture 4</a><br>
-                                <a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-4/r-diabetes.rar" class="mycol" target='_BLANK'>Lab 4</a><br>
-                                <a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-4/reading-4.rar" class="mycol" target='_BLANK'>Supplementary reading 4a: Logistic Regression</a>
+                        <td><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-4/l4.pdf" class="mycol" target='_BLANK'>Lecture 4</a><br>
+                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-4/r-diabetes.rar" class="mycol" target='_BLANK'>Lab 4</a><br>
+                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-4/reading-4.rar" class="mycol" target='_BLANK'>Supplementary reading 4a: Logistic Regression</a>
                                 </td>
                 </tr>
                 <tr class="row1">
                         <td>TBD</td>
                         <td>Lecture 5: SVM I</td>
-                        <td><a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-5-6/l5.pdf" class="mycol" target='_BLANK'>Lecture 5</a></td>
+                        <td><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-5-6/l5.pdf" class="mycol" target='_BLANK'>Lecture 5</a></td>
                 </tr>
                 <tr class="row2">
                         <td>TBD</td>
                         <td>Lecture 6: SVM II</td>
-                        <td><a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-5-6/l6.pdf" class="mycol" target='_BLANK'>Lecture 6</a><br>
-                                <a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-5-6/r-diabetes-revisit.rar" class="mycol" target='_BLANK'>Lab 6</a><br>
-                                <a href="https://github.com/wangshan731/DM-ML/raw/master/lecture-5-6/reading-svm.rar" class="mycol" target='_BLANK'>Supplementary reading 6a: SVM</a>
+                        <td><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-5-6/l6.pdf" class="mycol" target='_BLANK'>Lecture 6</a><br>
+                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-5-6/r-diabetes-revisit.rar" class="mycol" target='_BLANK'>Lab 6</a><br>
+                                <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/lecture-5-6/reading-svm.rar" class="mycol" target='_BLANK'>Supplementary reading 6a: SVM</a>
                                 </td>
                 </tr>
                 <tr class="row1">
@@ -223,11 +224,11 @@
         </table>
         <br>
         <p><b>Supplementary readings:</b></p>
-        <a href="https://github.com/wangshan731/DM-ML/raw/master/supplementary-reading/prob-for-ml.pdf" class="mycol" target='_BLANK'>Probability Theory</a>
-        <br><a href="https://github.com/wangshan731/DM-ML/raw/master/supplementary-reading/linear-algebra.pdf" class="mycol" target='_BLANK'>Linear Algebra</a>
-        <br><a href="https://github.com/wangshan731/DM-ML/raw/master/supplementary-reading/matrix-cookbook.pdf" class="mycol" target='_BLANK'>Matrix Cookbook</a>
-        <br><a href="https://github.com/wangshan731/DM-ML/raw/master/supplementary-reading/ml-advice.pdf" class="mycol" target='_BLANK'>Advice for Applying Machine Learning</a>
-        <br><a href="https://github.com/wangshan731/DM-ML/raw/master/supplementary-reading/ml-critiques.pdf" class="mycol" target='_BLANK'>Technical and Societal Critiques of ML</a>
-        
+        <a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/supplementary-reading/prob-for-ml.pdf" class="mycol" target='_BLANK'>Probability Theory</a>
+        <br><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/supplementary-reading/linear-algebra.pdf" class="mycol" target='_BLANK'>Linear Algebra</a>
+        <br><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/supplementary-reading/matrix-cookbook.pdf" class="mycol" target='_BLANK'>Matrix Cookbook</a>
+        <br><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/supplementary-reading/ml-advice.pdf" class="mycol" target='_BLANK'>Advice for Applying Machine Learning</a>
+        <br><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/supplementary-reading/ml-critiques.pdf" class="mycol" target='_BLANK'>Technical and Societal Critiques of ML</a>
+
 </body>
 <html>

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
         </table>
         <br>
         <div class="mycol"> <h3>Course Information</h3></div>
-        <p><b><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/@master/syllabus.pdf" class="mycol" target='_BLANK'>Syllabus</a></b></p>
+        <p><b><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/syllabus.pdf" class="mycol" target='_BLANK'>Syllabus</a></b></p>
         
         <p><b>Lecture Time & Location:</b></p>
         Mon. 10:00-11:40 (Week 1-9, 11 & 14-19)

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
         </table>
         <br>
         <div class="mycol"> <h3>Course Information</h3></div>
-        <p><b><a href="https://github.com/wangshan731/DM-ML/raw/master/syllabus.pdf" class="mycol" target='_BLANK'>Syllabus</a></b></p>
+        <p><b><a href="https://cdn.jsdelivr.net/gh/wangshan731/DM-ML/@master/syllabus.pdf" class="mycol" target='_BLANK'>Syllabus</a></b></p>
         
         <p><b>Lecture Time & Location:</b></p>
         Mon. 10:00-11:40 (Week 1-9, 11 & 14-19)


### PR DESCRIPTION
cdn全称内容分发网络，大概意思是把网站上的内容缓存到多个节点，以便于加速访问。jsdelivr是开源免费的cdn，可以免费加速github上的文件，且有国内节点（详见<https://www.jsdelivr.com/?docs=gh>）。对github 储存库上的静态文件添加cdn可以有效增加访问速度，避免了国内无法有效下载github文件的情况，往往比挂梯子更要快。然而jsdelivr cdn不支持超过20M的单个文件和超过50M的文件夹，因此视频文件和一些R的packages无法加速，但这些内容其实并不是特别重要的。

更换的链接已经手动测试，文件仍然指向 wangshan731/DM-ML 储存库。也可通过下面的页面测试
<https://jerrywang959.github.io/DM-ML/>